### PR TITLE
Add awaptools as a highlight of the unconference

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
   <a href="https://github.com/saundersk1/auunconf16">A collection of vignettes</a> for pulling Australian weather data into R.  
  </p>
  <p>
+  <a href="https://github.com/swish-climate-impact-assessment/awaptools">A package</a> for auto downloading, and unzipping Australian weather grids. 
+ </p>
+ <p>
  <a href="https://github.com/ropenscilabs/leafier">Leafier</a>, a proof of concept for enhancing the performance of large spatial datasets in leaflet.
  </p> 
  <p>


### PR DESCRIPTION
@njtierney this evolution of the `awaptools` package owes it's existence to the unconference, which I think is a highlight.
Include here if you agree.
Cheers, Ivan
